### PR TITLE
Handles unlimited range numbers

### DIFF
--- a/wtformsparsleyjs/core.py
+++ b/wtformsparsleyjs/core.py
@@ -77,7 +77,15 @@ def _ip_address_kwargs(kwargs):
 
 
 def _length_kwargs(kwargs, vali):
-    kwargs[u'data-rangelength'] = u'[' + str(vali.min) + u',' + str(vali.max) + u']'
+    default_number = -1
+
+    if vali.max != default_number and vali.min != default_number:
+        kwargs[u'data-rangelength'] = u'[' + str(vali.min) + u',' + str(vali.max) + u']'
+    else:
+        if vali.max == default_number:
+            kwargs[u'data-minlength'] = str(vali.min)
+        if vali.min == default_number:
+            kwargs[u'data-maxlength'] = str(vali.max)
 
 
 def _number_range_kwargs(kwargs, vali):


### PR DESCRIPTION
WTForms uses -1 to denote no min/max value. This makes the range and rangelength
validators incorrect. This patch falls back to min/max and minlength/maxlength
validation when one of the range values is -1.
